### PR TITLE
90 fix 0 starting digit in abn

### DIFF
--- a/src/Application/Common/Validators/AbnValidator.cs
+++ b/src/Application/Common/Validators/AbnValidator.cs
@@ -15,7 +15,7 @@ public class AbnValidator : AbstractValidator<string?>
     {
         _ = this.RuleFor(e => e)
             .Cascade(CascadeMode.Stop)
-            .Matches("^(\\d *?){11}$")
+            .Matches("^[1-9]\\d{10}$")
             .WithMessage("ABN must be an 11 digit number")
             .Must(IsValidAbn)
             .WithMessage("ABN is invalid")

--- a/src/Application/Common/Validators/AbnValidator.cs
+++ b/src/Application/Common/Validators/AbnValidator.cs
@@ -16,7 +16,7 @@ public class AbnValidator : AbstractValidator<string?>
         _ = this.RuleFor(e => e)
             .Cascade(CascadeMode.Stop)
             .Matches("^[1-9]\\d{10}$")
-            .WithMessage("ABN must be an 11 digit number")
+            .WithMessage("ABN must be an 11 digit number and cannot begin with 0.")
             .Must(IsValidAbn)
             .WithMessage("ABN is invalid")
             .When(e => !string.IsNullOrWhiteSpace(e));

--- a/tests/Application.UnitTests/Common/Validators/AbnValidatorTests.cs
+++ b/tests/Application.UnitTests/Common/Validators/AbnValidatorTests.cs
@@ -3,6 +3,7 @@ using FluentValidation;
 using FluentValidation.Results;
 using Moq;
 using VetCheckup.Application.Common.Validators;
+using VetCheckup.Application.UseCases.Organisations.CreateOrganisation;
 using Xunit;
 
 namespace VetCheckup.Application.UnitTests.Common.Validators;
@@ -24,7 +25,7 @@ public class AbnValidatorTests
     public void ValidAbn_NoValidationFailures()
     {
         // Arrange
-        _abn = "02110000000";
+        _abn = "48123123124";
 
         // Act
         var result = _abnValidator.Validate(_abn);
@@ -52,7 +53,7 @@ public class AbnValidatorTests
         {
             AttemptedValue = _abn,
             ErrorCode = "RegularExpressionValidator",
-            ErrorMessage = "ABN must be an 11 digit number"
+            ErrorMessage = "ABN must be an 11 digit number and cannot begin with 0."
         };
 
         // Act
@@ -74,7 +75,29 @@ public class AbnValidatorTests
         {
             AttemptedValue = _abn,
             ErrorCode = "RegularExpressionValidator",
-            ErrorMessage = "ABN must be an 11 digit number"
+            ErrorMessage = "ABN must be an 11 digit number and cannot begin with 0."
+        };
+
+        // Act
+        var result = _abnValidator.Validate(_abn);
+
+        // Assert
+        result.Errors
+            .Should().ContainEquivalentOf(expectedFailure, cfg => cfg
+            .Excluding(e => e.FormattedMessagePlaceholderValues)
+            .Excluding(e => e.PropertyName));
+    }
+
+    [Fact]
+    public void Abn_ZeroLeadingDigit_ValidationFailures()
+    {
+        // Arrange
+        _abn = "02110000000";
+        var expectedFailure = new ValidationFailure()
+        {
+            AttemptedValue = _abn,
+            ErrorCode = "RegularExpressionValidator",
+            ErrorMessage = "ABN must be an 11 digit number and cannot begin with 0."
         };
 
         // Act

--- a/tests/Application.UnitTests/UseCases/Organisations/CreateOrganisation/CreateOrganisationInteractorTests.cs
+++ b/tests/Application.UnitTests/UseCases/Organisations/CreateOrganisation/CreateOrganisationInteractorTests.cs
@@ -27,7 +27,7 @@ public class CreateOrganisationInteractorTests
     {
         _createOrganisationRequest = new CreateOrganisationRequest()
         {
-            Abn = "02110000000",
+            Abn = "48123123124",
             Address = new(),
             ContactDetails = new(),
             Name = "Giant Eagles Rescue",

--- a/tests/Application.UnitTests/UseCases/Organisations/CreateOrganisation/CreateOrganisationReqestValidatorTests.cs
+++ b/tests/Application.UnitTests/UseCases/Organisations/CreateOrganisation/CreateOrganisationReqestValidatorTests.cs
@@ -1,6 +1,7 @@
 ﻿using FluentAssertions;
 using FluentValidation;
 using FluentValidation.Results;
+using VetCheckup.Application.Common.Models;
 using VetCheckup.Application.UseCases.Organisations.CreateOrganisation;
 using VetCheckup.Domain.Enums;
 using Xunit;
@@ -62,7 +63,7 @@ public class CreateOrganisationReqestValidatorTests
         {
             AttemptedValue = _createOrganisationRequest.Abn,
             ErrorCode = "RegularExpressionValidator",
-            ErrorMessage = "ABN must be an 11 digit number"
+            ErrorMessage = "ABN must be an 11 digit number and cannot begin with 0."
         };
 
         // Act
@@ -84,7 +85,29 @@ public class CreateOrganisationReqestValidatorTests
         {
             AttemptedValue = _createOrganisationRequest.Abn,
             ErrorCode = "RegularExpressionValidator",
-            ErrorMessage = "ABN must be an 11 digit number"
+            ErrorMessage = "ABN must be an 11 digit number and cannot begin with 0."
+        };
+
+        // Act
+        var result = _createOrganisationRequestValidator.Validate(_createOrganisationRequest);
+
+        // Assert
+        result.Errors
+            .Should().ContainEquivalentOf(expectedFailure, cfg => cfg
+            .Excluding(e => e.FormattedMessagePlaceholderValues)
+            .Excluding(e => e.PropertyName));
+    }
+
+    [Fact]
+    public void Abn_ZeroLeadingDigit_ValidationFailures()
+    {
+        // Arrange
+        _createOrganisationRequest.Abn = "02110000000";
+        var expectedFailure = new ValidationFailure()
+        {
+            AttemptedValue = _createOrganisationRequest.Abn,
+            ErrorCode = "RegularExpressionValidator",
+            ErrorMessage = "ABN must be an 11 digit number and cannot begin with 0."
         };
 
         // Act

--- a/tests/Application.UnitTests/UseCases/Organisations/UpdateOrganisation/UpdateOrganisationInteractorTests.cs
+++ b/tests/Application.UnitTests/UseCases/Organisations/UpdateOrganisation/UpdateOrganisationInteractorTests.cs
@@ -41,7 +41,7 @@ namespace VetCheckup.Application.UnitTests.UseCases.Organisations.UpdateOrganisa
                 .Returns(new List<Organisation> { new Organisation
                         {
                             OrganisationId = _updateOrganisationRequest.OrganisationId,
-                            Abn = "02110000000",
+                            Abn = "48123123124",
                             Address = new Address()
                             {
                                 Country = "Country",

--- a/tests/Application.UnitTests/UseCases/Organisations/UpdateOrganisation/UpdateOrganisationRequestValidatorTests.cs
+++ b/tests/Application.UnitTests/UseCases/Organisations/UpdateOrganisation/UpdateOrganisationRequestValidatorTests.cs
@@ -1,7 +1,6 @@
 ﻿using FluentAssertions;
 using FluentValidation;
 using FluentValidation.Results;
-using VetCheckup.Application.UseCases.Organisations.CreateOrganisation;
 using VetCheckup.Application.UseCases.Organisations.UpdateOrganisation;
 using VetCheckup.Domain.Enums;
 using Xunit;
@@ -64,7 +63,7 @@ namespace VetCheckup.Application.UnitTests.UseCases.Organisations.UpdateOrganisa
             {
                 AttemptedValue = _updateOrganisationRequest.Abn,
                 ErrorCode = "RegularExpressionValidator",
-                ErrorMessage = "ABN must be an 11 digit number"
+                ErrorMessage = "ABN must be an 11 digit number and cannot begin with 0."
             };
 
             // Act
@@ -86,7 +85,29 @@ namespace VetCheckup.Application.UnitTests.UseCases.Organisations.UpdateOrganisa
             {
                 AttemptedValue = _updateOrganisationRequest.Abn,
                 ErrorCode = "RegularExpressionValidator",
-                ErrorMessage = "ABN must be an 11 digit number"
+                ErrorMessage = "ABN must be an 11 digit number and cannot begin with 0."
+            };
+
+            // Act
+            var result = _updateOrganisationRequestValidator.Validate(_updateOrganisationRequest);
+
+            // Assert
+            result.Errors
+                .Should().ContainEquivalentOf(expectedFailure, cfg => cfg
+                .Excluding(e => e.FormattedMessagePlaceholderValues)
+                .Excluding(e => e.PropertyName));
+        }
+
+        [Fact]
+        public void Abn_ZeroLeadingDigit_ValidationFailures()
+        {
+            // Arrange
+            _updateOrganisationRequest.Abn = "02110000000";
+            var expectedFailure = new ValidationFailure()
+            {
+                AttemptedValue = _updateOrganisationRequest.Abn,
+                ErrorCode = "RegularExpressionValidator",
+                ErrorMessage = "ABN must be an 11 digit number and cannot begin with 0."
             };
 
             // Act
@@ -192,7 +213,7 @@ namespace VetCheckup.Application.UnitTests.UseCases.Organisations.UpdateOrganisa
             var result = _updateOrganisationRequestValidator.Validate(_updateOrganisationRequest);
 
             // Assert
-            result.Errors.Where(e => e.PropertyName.Equals(nameof(CreateOrganisationRequest.OrganisationType), StringComparison.OrdinalIgnoreCase))
+            result.Errors.Where(e => e.PropertyName.Equals(nameof(UpdateOrganisationRequest.OrganisationType), StringComparison.OrdinalIgnoreCase))
                 .Should().BeEmpty();
         }
 


### PR DESCRIPTION
Changed requirements in ABN to now not allow a 0 in the first digit. Regex in validator also allowed spaces between digits, which we should not allow.